### PR TITLE
Update Install Docs For Ubuntu 18.04

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -20,7 +20,7 @@ apt install git postgresql nginx libdbd-pg-perl starman \
   libtest-warnings-perl libhttp-browserdetect-perl libtest-exception-perl \
   libdbd-sqlite3-perl libmoose-perl dh-make-perl
 
-# If installing on recent versions of Ubuntu - install required Perl module required for next steps
+# If installing on recent versions of Ubuntu this package required to build Dancer2 Auth modules
 dh-make-perl --install --cpan Test::Fatal
 
 # Some perl modules are not packaged by Debian - make and install

--- a/INSTALL
+++ b/INSTALL
@@ -20,6 +20,9 @@ apt install git postgresql nginx libdbd-pg-perl starman \
   libtest-warnings-perl libhttp-browserdetect-perl libtest-exception-perl \
   libdbd-sqlite3-perl libmoose-perl dh-make-perl
 
+# If installing on recent versions of Ubuntu - install required Perl module required for next steps
+dh-make-perl --install --cpan Test::Fatal
+
 # Some perl modules are not packaged by Debian - make and install
 # them ourselves
 dh-make-perl --install --cpan Parse::CSV

--- a/INSTALL
+++ b/INSTALL
@@ -5,6 +5,7 @@
 #  Otherwise this should run on anything that supports Perl.
 #
 #  Instructions tested 2019-01-05 on a base-spec VPS from Bytemark
+#  Instructions tested 2020-05-28 on Ubuntu 18.04
 
 
 # Install needed system packages

--- a/INSTALL
+++ b/INSTALL
@@ -12,7 +12,7 @@
 # Running as root:
 apt-get update
 apt-get upgrade
-apt install git postgresql nginx libdbd-pg-perl starman \
+apt install git postgresql-10 nginx libdbd-pg-perl starman \
   libexcel-writer-xlsx-perl libdancer2-perl libarray-utils-perl \
   libtext-csv-xs-perl libcrypt-saltedhash-perl \
   libjson-xs-perl libjson-perl libdancer2-plugin-database-perl \

--- a/INSTALL
+++ b/INSTALL
@@ -86,7 +86,7 @@ END_OF_SERVICE
 # editor to make the change manually.
 sed -i \
   's/^local\s*all\s*postgres\s*peer$/local   kronekeeper     kkdancer    md5\n&/' \
-  /etc/postgresql/9.6/main/pg_hba.conf
+  /etc/postgresql/10/main/pg_hba.conf
 
 
 # Configure nginx as a reverse proxy for Kronekeeper.


### PR DESCRIPTION
This pull request updates the INSTALL script to work properly on Ubuntu 18.04. I believe this should also work for newer CentOS installs as well, although it has not been tested.

Edits come from my experience setting up a new instance.